### PR TITLE
use cmake3 for newer builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
   apt:
     packages:
     - g++-mingw-w64
+    - cmake3
 before_script:
 - export PATH="$HOME/bin:$PATH"
 - make -f texinfo-travis.mk install_texinfo


### PR DESCRIPTION
Required  for updates in vitasdk/buildscripts#45. The new CMakeLists requires a newer cmake version to handle lzma compressed tarballs.