### PR TITLE
RFC: Build a dynamically linked toolchain on linux with musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     packages:
     - g++-mingw-w64
     - cmake3
+    - realpath
 before_script:
 - export PATH="$HOME/bin:$PATH"
 - make -f texinfo-travis.mk install_texinfo

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -e
+
+echo "==> Download and compile patchelf"
+wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
+tar xvf patchelf-0.9.tar.bz2
+pushd patchelf-0.9
+./configure
+make
+popd
+
+# We're using a musl toolchain
+echo "==> Obtain static musl toolchain"
+curl http://dl.vitasdk.org/static-musl-for-travis.tar.gz | tar xzv
+export PATH=$(pwd)/static-musl-for-travis/bin/:$PATH
+ln -s x86_64-linux-musl-gcc $(pwd)/static-musl-for-travis/bin/gcc
+
+echo "==> Compile vitasdk"
+# dynamic-linker is bogus, just to get the executable to run on travis
+export LD_LIBRARY_PATH=$(pwd)/static-musl-for-travis/x86_64-linux-musl/lib/
+LINKFLAGS="-Wl,--dynamic-linker,$LD_LIBRARY_PATH/libc.so"
+export CC="x86_64-linux-musl-gcc $LINKFLAGS"
+export CXX="x86_64-linux-musl-g++ $LINKFLAGS"
+cmake ..
+make -j4 tarball
+
+# now comes the fun part
+echo "==> Extract vitasdk"
+mkdir -p patch
+pushd patch
+oldname=$(basename ../vitasdk-*.tar.bz2)
+tar xvf ../$oldname
+
+pushd vitasdk
+echo "==> Patch executable binaries"
+FILES=$(find . -type f -executable | xargs file | grep ELF | grep executable | cut -d':' -f1)
+
+for file in $FILES; do
+	if [[ $file != _* ]]; then
+		echo "-- Patching $file"
+
+		# We don't want people to accidentally execute the _$file without the wrapper
+		$PWD/../../patchelf-0.9/src/patchelf --set-interpreter /should/not/exist $file
+		name=$(basename $file)
+		dirpath=$(dirname $file)
+
+		# Depending on where the executable is, different number of ../../ in the relative path
+		relative=$(realpath --relative-to="$dirpath" "lib/libmusl_vitasdk.so")
+
+		# Store "real" executable as _name, e.g. _vita-pack-vpk
+		mv $file $dirpath/_$name
+
+		# The wrapper script will execute our real executable providing full path to program interpreter
+		echo -n "" > $file
+		echo "#!/bin/sh" >> $file
+		echo 'HERE=$(dirname "$0")' >> $file
+		echo "\$HERE/$relative --argv0=$name -- \$HERE/_$name \"\$@\"" >> $file
+
+		chmod +x $file
+	fi;
+done
+
+echo "==> Deploy libmusl_vitasdk.so"
+cp $LD_LIBRARY_PATH/libc.so lib/libmusl_vitasdk.so
+
+popd
+
+echo "==> Archive patched vitasdk"
+tar cfvj $oldname vitasdk
+
+# and replace it
+mv $oldname ../
+
+popd

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-echo "==> Download and compile patchelf"
-wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
-tar xvf patchelf-0.9.tar.bz2
-pushd patchelf-0.9
-./configure
-make
-popd
-
 # We're using a musl toolchain
 echo "==> Obtain static musl toolchain"
 curl http://dl.vitasdk.org/static-musl-for-travis.tar.gz | tar xzv
@@ -40,8 +32,6 @@ for file in $FILES; do
 	if [[ $file != _* ]]; then
 		echo "-- Patching $file"
 
-		# We don't want people to accidentally execute the _$file without the wrapper
-		$PWD/../../patchelf-0.9/src/patchelf --set-interpreter /should/not/exist $file
 		name=$(basename $file)
 		dirpath=$(dirname $file)
 

--- a/build_internal.sh
+++ b/build_internal.sh
@@ -13,15 +13,10 @@ make -j4 tarball
 mkdir build
 cd build
 if [[ $(uname -s) = "Linux" ]]; then
-	curl http://dl.vitasdk.org/static-musl-for-travis.tar.gz | tar xzv
-	export PATH=$(pwd)/static-musl-for-travis/bin/:$PATH
-	ln -s x86_64-linux-musl-gcc $(pwd)/static-musl-for-travis/bin/gcc
-	export CC="x86_64-linux-musl-gcc -static --static"
-	export CXX="x86_64-linux-musl-g++ -static --static"
-	cmake ..
+	../../build-linux.sh
 else
 	cmake ..
+	make -j4 tarball
 fi
-make -j4 tarball
       ;;
 esac


### PR DESCRIPTION
This changes from building statically linked musl toolchain to dynamically linked musl toolchain.

To work around `PT_INTERP` only allowed to be absolute path, we replace all executables with shell scripts that execute program interpreter (libmusl_vitasdk.so) directly.

This should fix build with lto enabled on Linux.

I'm marking this as RFC because I'm not sure it's worth the effort - maybe it's better just to revert the static-musl commit. In its current state, lto appears to work (at least, there are no errors), however it seems to break fakeroot

```
==> Tidying install...
  -> Purging unwanted files...
  -> Stripping unneeded symbols from binaries and libraries...
Error relocating /usr/lib/libfakeroot/libfakeroot.so: __snprintf_chk: symbol not found
Error relocating /usr/lib/libfakeroot/libfakeroot.so: __memcpy_chk: symbol not found
Error relocating /usr/lib/libfakeroot/libfakeroot.so: __fprintf_chk: symbol not found
```

(fakeroot works by doing an LD_PRELOAD of libfakeroot.so, which on my system is linked against system glibc. Actually, it's probably broken with static musl toolchain as well but you don't see it because LD_PRELOAD is silently ignored in that case?)