### PR TITLE
github: remove actions/setup-python@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -51,7 +50,6 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
     - name: Install dependencies
       run: |
         brew install autoconf automake libtool
@@ -91,7 +89,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
CI runs fine without it and actions/setup-python@v2 uses node12 which is deprecated:
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/