### PR TITLE
Add support for linux-arm64 using ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         make -j$(nproc) tarball
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vitasdk-linux
         path: buildscripts/build/*.tar.bz2
@@ -73,7 +73,7 @@ jobs:
         make -j$(nproc) tarball
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vitasdk-linux-arm64
         path: buildscripts/build/*.tar.bz2
@@ -110,7 +110,7 @@ jobs:
         make -j$(nproc) tarball
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vitasdk-macos
         path: buildscripts/build/*.tar.bz2
@@ -154,7 +154,7 @@ jobs:
         make -j$(nproc) tarball
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vitasdk-windows
         path: buildscripts/build/*.tar.bz2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
   build-linux:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -47,11 +47,50 @@ jobs:
         file_glob: true
         tag: master-linux-v2.${{github.run_number}}     
         release_name: master-linux-v2.${{github.run_number}}
+  build-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
+        sudo apt-get install -y cmake cmake-data git build-essential autoconf automake libtool texinfo bison flex pkg-config
+    - name: Clone
+      run: |
+        export REV=dirty-$(git describe --always)
+        git clone https://github.com/vitasdk/buildscripts.git
+        chmod +x *.sh
+    - name: Build
+      run: |
+        cd buildscripts
+        git config --global user.email "builds@travis-ci.com"
+        git config --global user.name "Travis CI"
+        mkdir build
+        cd build
+        cmake ..
+        make -j$(nproc) tarball
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: vitasdk-linux-arm64
+        path: buildscripts/build/*.tar.bz2
+    - uses: svenstaro/upload-release-action@v2
+      if: contains(github.ref,'refs/heads/master')
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: buildscripts/build/*.tar.bz2
+        overwrite: true
+        file_glob: true
+        tag: master-linux-arm64-v2.${{github.run_number}}     
+        release_name: master-linux-arm64-v2.${{github.run_number}}
   build-macos:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: Install dependencies
       run: |
         brew install autoconf automake libtool
@@ -90,8 +129,8 @@ jobs:
     # mingw output have to be static linking, and that this reason, we are able to use 22.04 in here
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
- Updates github workflows to use the arm64 runner for aarch64. 
- Update github actions:
  - Use actions/checkout@v4
  - Use actions/setup-python@v5
  - Use actions/upload-artifact@v4

I have also updated vdpm to check for linux arch (https://github.com/vitasdk/vdpm/pull/107)

This needs to run first before the VDPM pull request can be accepted.