### PR TITLE
Build the core against vdpm 0.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,12 @@ jobs:
         include:
           - name: linux-x86_64
             runner: ubuntu-24.04
+            container: ubuntu:20.04
             host: x86_64-linux-gnu
             vdpm_sha256: bc030236db0892aa0afd6ab02b914f56573c178c34a47077d0eef4d4503e07d5
           - name: linux-aarch64
             runner: ubuntu-24.04-arm
+            container: ubuntu:20.04
             host: aarch64-linux-gnu
             vdpm_sha256: 14d2d154d6073a4a292d1b2b7e73cab2ef90934b130b0e08b9d4246c4b012da0
           - name: macos-arm64
@@ -76,16 +78,24 @@ jobs:
             host: arm64-apple-darwin
             vdpm_sha256: 8e53c32b5f52da627500f4f697adc4a8fdd20e930976ee1a4b4b6df8a04f356a
     runs-on: ${{ matrix.runner }}
+    # The Linux legs build inside ubuntu:20.04 so the published SDK runs on
+    # glibc 2.31 hosts, matching the vdpm bundles built the same way.
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            autoconf automake bison build-essential ccache cmake flex gettext \
-            libarchive-tools libtool pkg-config texinfo
+          apt-get update
+          apt-get install -y \
+            autoconf automake bison build-essential bzip2 ccache curl flex \
+            gettext git libarchive-tools libtool pkg-config python3-pip \
+            texinfo xz-utils
+          # focal's cmake predates the package client's 3.20 floor.
+          pip3 install --quiet cmake==3.31.6
 
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
@@ -118,38 +128,30 @@ jobs:
       - name: Download exact vdpm host component
         id: vdpm
         env:
-          GH_TOKEN: ${{ github.token }}
           VDPM_HOST: ${{ matrix.host }}
           VDPM_SHA256: ${{ matrix.vdpm_sha256 }}
         shell: bash
         run: |
           mkdir vdpm-release
-          gh release download "$VDPM_RELEASE_TAG" --repo vitasdk/vdpm \
-            --pattern "vdpm-*-$VDPM_HOST.tar.bz2" \
-            --pattern "vdpm-*-$VDPM_HOST.tar.bz2.sha256" \
-            --dir vdpm-release
-          archive_count=$(find vdpm-release -maxdepth 1 -type f \
-            -name "vdpm-*-$VDPM_HOST.tar.bz2" | wc -l)
-          sidecar_count=$(find vdpm-release -maxdepth 1 -type f \
-            -name "vdpm-*-$VDPM_HOST.tar.bz2.sha256" | wc -l)
-          [[ $archive_count -eq 1 && $sidecar_count -eq 1 ]]
-          archive=$(find vdpm-release -maxdepth 1 -type f \
-            -name "vdpm-*-$VDPM_HOST.tar.bz2" -print -quit)
-          sidecar=$(find vdpm-release -maxdepth 1 -type f \
-            -name "vdpm-*-$VDPM_HOST.tar.bz2.sha256" -print -quit)
+          archive="vdpm-${VDPM_RELEASE_TAG#v}-$VDPM_HOST.tar.bz2"
+          base="https://github.com/vitasdk/vdpm/releases/download/$VDPM_RELEASE_TAG"
+          curl -fsSL --retry 3 -o "vdpm-release/$archive" "$base/$archive"
+          curl -fsSL --retry 3 -o "vdpm-release/$archive.sha256" "$base/$archive.sha256"
           if command -v sha256sum >/dev/null; then
-            actual=$(sha256sum "$archive")
+            actual=$(sha256sum "vdpm-release/$archive")
           else
-            actual=$(shasum -a 256 "$archive")
+            actual=$(shasum -a 256 "vdpm-release/$archive")
           fi
           actual=${actual%% *}
-          sidecar_digest=$(awk '{print $1}' "$sidecar")
+          sidecar_digest=$(awk '{print $1}' "vdpm-release/$archive.sha256")
           [[ $actual == "$VDPM_SHA256" && $sidecar_digest == "$VDPM_SHA256" ]]
-          echo "archive=$PWD/$archive" >> "$GITHUB_OUTPUT"
+          echo "archive=$PWD/vdpm-release/$archive" >> "$GITHUB_OUTPUT"
 
       - name: Build core package, bootstrap and compatibility archive
         shell: bash
         run: |
+          # focal images carry no default locale and GCC's tarball needs one.
+          export LANG=C.UTF-8
           cmake -S buildscripts -B buildscripts/build \
             -DBUILD_PACMAN_CLIENT=ON \
             -DPACMAN_CLIENT_INSTALL_DIR="$PWD/buildscripts/build/vitasdk" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  VDPM_RELEASE_TAG: v0.1.1
-  VDPM_WINDOWS_SHA256: 9413c6ceddb3e836c279993549a1da7e800cd53e9863c5bfbf8ba1cf10215132
+  VDPM_RELEASE_TAG: v0.1.2
+  VDPM_WINDOWS_SHA256: b3baf28a8ea870e32661c746e6f75b0480b3a6dad8f33aa7a0df7b90a55833c7
 
 jobs:
   prepare:
@@ -66,15 +66,15 @@ jobs:
           - name: linux-x86_64
             runner: ubuntu-24.04
             host: x86_64-linux-gnu
-            vdpm_sha256: 9ca0ca6dbc06c1cc44c2a46a5eb977be1b371bfa40b3319ce950673ccc58dc54
+            vdpm_sha256: bc030236db0892aa0afd6ab02b914f56573c178c34a47077d0eef4d4503e07d5
           - name: linux-aarch64
             runner: ubuntu-24.04-arm
             host: aarch64-linux-gnu
-            vdpm_sha256: db2a2c04f1fb673f357f77b5513298b75b036465e2368dc7924a456be3e3ed7b
+            vdpm_sha256: 14d2d154d6073a4a292d1b2b7e73cab2ef90934b130b0e08b9d4246c4b012da0
           - name: macos-arm64
             runner: macos-15
             host: arm64-apple-darwin
-            vdpm_sha256: a1fa4654cbeb389fa8c22c90df9e644e710704919ee846074f69092b335f9c06
+            vdpm_sha256: 8e53c32b5f52da627500f4f697adc4a8fdd20e930976ee1a4b4b6df8a04f356a
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Companion to vitasdk/buildscripts#153, which just landed: the packaging scripts on buildscripts master now expect the `libexec/vdpm` layout that vdpm ships since v0.1.2, so this bumps `VDPM_RELEASE_TAG` to v0.1.2 with the four refreshed bundle sha256s, and builds the Linux cores inside `ubuntu:20.04` so the published SDKs keep the same glibc floor as the client bundles.

Merging this right behind #153 keeps the toolchain and the client coherent in a single publication window.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).
