### PR TITLE
Give the Windows cross the Linux SDK it now imports from

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             buildscripts/build/vitasdk/share/vdpm/bootstrap-vitasdk.sh \
                --install-dir "$install_root"
           VITASDK="$install_root" "$install_root/bin/vdpm" --help >/dev/null
-          "$install_root/bin/pacman" --version >/dev/null
+          "$install_root/libexec/vdpm/pacman" --version >/dev/null
           "$install_root/bin/arm-vita-eabi-gcc" --version
 
       - name: Stage host artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,9 @@ jobs:
           retention-days: 14
 
   build-windows:
-    needs: prepare
+    # The canadian cross imports the target half from the Linux SDK and needs
+    # its arm-vita-eabi-gcc as the compiler that runs where it builds.
+    needs: [prepare, build-core]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
@@ -271,12 +273,32 @@ jobs:
           [[ $actual == "$VDPM_WINDOWS_SHA256" ]]
           (cd vdpm-release && sha256sum -c *.tar.bz2.sha256)
           echo "archive=$PWD/$archive" >> "$GITHUB_OUTPUT"
+      - name: Fetch the build machine's SDK
+        uses: actions/download-artifact@v7
+        with:
+          name: core-linux-x86_64
+          path: build-sdk-artifact
+      - name: Unpack the build machine's SDK
+        shell: bash
+        run: |
+          mapfile -t sdks < <(find build-sdk-artifact -maxdepth 1 -type f \
+            -name 'vitasdk-*.tar.bz2' ! -name 'vitasdk-bootstrap-*')
+          [[ ${#sdks[@]} -eq 1 ]]
+          mkdir -p build-sdk
+          tar -xjf "${sdks[0]}" -C build-sdk
+          STAGE1_DIR=$(dirname "$(dirname "$(dirname "$(find "$PWD/build-sdk" -type f -path '*/arm-vita-eabi/lib/libc.a' | head -1)")")")
+          test -n "$STAGE1_DIR"
+          echo "STAGE1_DIR=$STAGE1_DIR" >> "$GITHUB_ENV"
+          # gcc runs arm-vita-eabi-gcc -dumpspecs during all-gcc; this is the
+          # one that runs here.
+          echo "$STAGE1_DIR/bin" >> "$GITHUB_PATH"
       - name: Build Windows core package, bootstrap and compatibility archive
         shell: bash
         run: |
           unset CC CXX
           cmake -S buildscripts -B buildscripts/build \
             -DCMAKE_TOOLCHAIN_FILE="$PWD/buildscripts/toolchain-x86_64-w64-mingw32.cmake" \
+            -DVITASDK_STAGE1_DIR="$STAGE1_DIR" \
             -DBUILD_PACMAN_CLIENT=ON \
             -DVDPM_BUNDLE='${{ steps.vdpm.outputs.archive }}' \
             -DVDPM_BUNDLE_SHA256="$VDPM_WINDOWS_SHA256" \


### PR DESCRIPTION
The first master run after #30 surfaced two leftovers from the monolithic world, both deterministic; this PR carries the pair so one CI run exercises the whole chain.

**1. `build-windows` refused to configure.** The staged buildscripts rejects a bare cross configure by design — target code is compiled once, natively, and every other host imports it (`Cross building needs a stage-1 SDK ... pass VITASDK_STAGE1_DIR`). This mirrors what buildscripts' own stage 3 does for its canadian crosses: `build-windows` now waits for `build-core`, unpacks the `core-linux-x86_64` SDK tarball as the build machine's SDK, points `VITASDK_STAGE1_DIR` at it, and puts its `arm-vita-eabi-gcc` on PATH (gcc runs it for `-dumpspecs` during all-gcc, and the mingw one cannot run here). The stage-1 sysroot artifact alone would not do: it deliberately carries no host binaries, and a canadian cross needs a vita compiler that runs where it builds.

**2. The bootstrap smoke probe looked for pacman in `bin/`.** The v0.1.2 bundle installs the Linux and macOS pacman under `libexec/vdpm/` — the same move the Windows probe already followed in 7357f5b — so `build-core` failed its bootstrap exercise after a successful build.

The PR's own CI run exercises cores + Windows cross end to end before this touches master; publishing stays master-only.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).