### PR TITLE
Read the channel from the dispatch instead of assuming nightly

### DIFF
--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -69,13 +69,13 @@ jobs:
           elif [[ -n '${{ github.event.client_payload.packages_snapshot }}' ]]; then
             pkgs='${{ github.event.client_payload.packages_snapshot }}'
             core='${{ github.event.client_payload.core_snapshot }}'
-            chan='nightly'
+            chan='${{ github.event.client_payload.channel }}'
             seq=""
             b_sha='${{ github.event.client_payload.buildscripts_sha }}'
           fi
-          
-          if [[ -z "$core" || -z "$pkgs" ]]; then
-            echo "::error::Both core_release and packages_release must be explicitly provided (no latest-release fallback allowed)"
+
+          if [[ -z "$core" || -z "$pkgs" || -z "$chan" ]]; then
+            echo "::error::core_release, packages_release and channel must all be explicitly provided (no default fallback allowed)"
             exit 1
           fi
           

--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -41,6 +41,9 @@ permissions:
 jobs:
   update-channel:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: channel-${{ github.event.client_payload.channel || inputs.channel || 'dispatch' }}
+      cancel-in-progress: false
     env:
       # The catalogue lives in its own repository now. Whoever asks for a
       # manifest says where the packages are, and the manifest records it so

--- a/tests/test-pipeline-contracts.sh
+++ b/tests/test-pipeline-contracts.sh
@@ -119,4 +119,17 @@ grep -q '\-z "\$chan"' "$AUTOBUILDS_ROOT/.github/workflows/channel.yml" || {
 }
 echo "PASS: Test F (channel comes from the dispatch payload)"
 
+# --- Test G: two publishes for the same channel must not race ---
+echo "--- Test G: update-channel serializes publishes per channel ---"
+python3 -c "
+import yaml
+with open('$AUTOBUILDS_ROOT/.github/workflows/channel.yml') as f:
+    doc = yaml.safe_load(f)
+job = doc['jobs']['update-channel']
+assert 'concurrency' in job, 'update-channel has no concurrency group'
+assert job['concurrency']['cancel-in-progress'] is False, \
+    'a half-finished manifest push must not be cancelled by a second one'
+"
+echo "PASS: Test G (update-channel has a serializing concurrency group)"
+
 echo "=== All cross-repository pipeline contract tests PASSED successfully! ==="

--- a/tests/test-pipeline-contracts.sh
+++ b/tests/test-pipeline-contracts.sh
@@ -102,4 +102,21 @@ grep -q -- '--output "$provenance_tmp" --clobber' \
 }
 echo "PASS: Test E (provenance download overwrites its own temporary file)"
 
+# --- Test F: repository_dispatch must read the channel, not hardcode it ---
+echo "--- Test F: channel comes from the dispatch payload, not a literal ---"
+if grep -q "chan='nightly'" "$AUTOBUILDS_ROOT/.github/workflows/channel.yml"; then
+    echo "FAIL: channel.yml still hardcodes the repository_dispatch channel to nightly" >&2
+    exit 1
+fi
+grep -q "chan='\${{ github.event.client_payload.channel }}'" \
+    "$AUTOBUILDS_ROOT/.github/workflows/channel.yml" || {
+    echo "FAIL: channel.yml does not read channel from client_payload.channel" >&2
+    exit 1
+}
+grep -q '\-z "\$chan"' "$AUTOBUILDS_ROOT/.github/workflows/channel.yml" || {
+    echo "FAIL: channel.yml does not require channel like it requires core/packages" >&2
+    exit 1
+}
+echo "PASS: Test F (channel comes from the dispatch payload)"
+
 echo "=== All cross-repository pipeline contract tests PASSED successfully! ==="


### PR DESCRIPTION
Two standalone fixes to the channel publication path, to be merged in the same window as its twin in `vitasdk-autobuild` (which is what starts sending the field this one now requires).

**The channel is no longer hardcoded.** A `repository_dispatch` arriving to publish a manifest had its channel pinned to the literal `nightly`, ignoring what the sender asked for. Harmless while nightly is the only channel; the day a release series exists, a publication would silently land on the wrong one. The channel now comes from `client_payload.channel`, and a payload that carries none fails loudly naming the field rather than guessing — which is why the twin PR must land in the same window.

**Publishes to one channel are serialized.** `update-channel` gains a concurrency group keyed on the channel with `cancel-in-progress: false`: two publications of the same channel can no longer interleave mid-write, and a half-finished manifest push is never cancelled by a later one. Different channels still run in parallel.

Contract tests for both are wired into `tests/test-pipeline-contracts.sh`.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).