### PR TITLE
Tell the package autobuilder which series a core belongs to

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       buildscripts_revision: ${{ steps.describe.outputs.buildscripts_revision }}
       build_id: ${{ steps.describe.outputs.build_id }}
       version: ${{ steps.describe.outputs.version }}
+      series: ${{ steps.describe.outputs.series }}
       lock: ${{ steps.describe.outputs.lock }}
     steps:
       - id: ref
@@ -57,7 +58,9 @@ jobs:
             cat "$lock_path"
             echo "LOCK_JSON_EOF"
           } >> "$GITHUB_OUTPUT"
-          jq -r '"build_id=\(.build_id)", "buildscripts_revision=\(.buildscripts_revision)", "version=\(.version)"' \
+          # series is null for a nightly and the series name for a
+          # release, so the announcement below never has to guess.
+          jq -r '"build_id=\(.build_id)", "buildscripts_revision=\(.buildscripts_revision)", "version=\(.version)", "series=\(.series // "")"' \
             "$lock_path" >> "$GITHUB_OUTPUT"
 
       - name: Check the required hosts are buildable at this revision
@@ -156,4 +159,5 @@ jobs:
           fi
           gh api repos/vitasdk/vitasdk-autobuild/dispatches \
             -f event_type=core_published \
-            -f client_payload[core_snapshot]="${{ steps.publish.outputs.snapshot_tag }}"
+            -f client_payload[core_snapshot]="${{ steps.publish.outputs.snapshot_tag }}" \
+            -f client_payload[series]="${{ needs.prepare.outputs.series }}"


### PR DESCRIPTION
The announcement to the package autobuilder carried the core snapshot and nothing else:

```yaml
-f client_payload[core_snapshot]="${{ steps.publish.outputs.snapshot_tag }}"
```

`core-update` reads the series from that payload, and an empty series names the unnamed one — nightly. Harmless while every core published was a nightly. It stops being harmless with the first patch: `2026.08.1` carries the target runtime of its series, newlib `6cba9812`, which is 2445 commits behind the development branch. Announcing it without a series would have pointed nightly at it.

The series now comes straight out of the lock, which `buildscripts` fills in from the declared version ([buildscripts#164](https://github.com/vitasdk/buildscripts/pull/164)). Nothing here parses a version string, which is the rule this repository is meant to keep. `jq`'s `.series // ""` means a lock without the field — every lock built before it existed, and every lock from a `buildscripts` that predates the change — yields the empty string and the behaviour this workflow has today.

Merge order does not matter: this change is inert until a lock arrives carrying a series, and that lock is inert until something reads it.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
