### PR TITLE
Offer the hosts a core published, not the four written down here

### DIFF
--- a/scripts/generate-channel-manifest.py
+++ b/scripts/generate-channel-manifest.py
@@ -13,13 +13,6 @@ import subprocess
 import sys
 import urllib.request
 
-HOST_ARCHITECTURES = [
-    "aarch64-linux-gnu",
-    "arm64-apple-darwin",
-    "x86_64-linux-gnu",
-    "x86_64-w64-mingw32",
-]
-
 def fetch_sha256(url: str) -> str:
     """Download a file or sidecar and compute/extract SHA256 digest."""
     req = urllib.request.Request(url, headers={"User-Agent": "vitasdk-manifest-generator"})
@@ -47,6 +40,43 @@ def get_digest(base_url: str, asset_name: str, local_dir: str = None) -> str:
     except Exception:
         asset_url = f"{base_url}/{asset_name}"
         return fetch_sha256(asset_url)
+
+def core_hosts(core_repository: str, core_release: str, core_dir: str = None) -> list:
+    """Which hosts a core release actually published.
+
+    Read off the release rather than listed here: the manifest maps one
+    database per host, so the databases a release carries *are* its hosts,
+    and there is no second list to fall behind. This one did -- the core
+    published nine hosts while the channel kept offering four, so musl,
+    FreeBSD and Intel macOS had a core nobody could install.
+
+    An older release simply carries fewer, which is what a series pinned to
+    an old core needs.
+    """
+
+    if core_dir:
+        names = os.listdir(core_dir)
+    else:
+        url = f"https://api.github.com/repos/{core_repository}/releases/tags/{core_release}"
+        request = urllib.request.Request(url, headers={
+            "User-Agent": "vitasdk-manifest-generator",
+            "Accept": "application/vnd.github+json",
+        })
+        # Anonymous quota on a runner is shared and routinely spent; without
+        # this the failure arrives as a bare 403.
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request) as response:
+            names = [asset["name"] for asset in json.load(response)["assets"]]
+
+    hosts = sorted(name[:-len(".db")] for name in names if name.endswith(".db"))
+    if not hosts:
+        raise SystemExit(
+            f"ERROR: {core_release} carries no host database, so there is "
+            "nothing to offer; refusing to publish a channel with no hosts")
+    return hosts
+
 
 def read_deprecated(path):
     """The deprecated packages published with the snapshot, if it carries any.
@@ -84,7 +114,7 @@ def build_manifest(
     packages_base = f"https://github.com/{packages_repository}/releases/download/{packages_release}"
 
     architectures = {}
-    for host in HOST_ARCHITECTURES:
+    for host in core_hosts(core_repository, core_release, core_dir):
         db_name = f"{host}.db"
         digest = get_digest(core_base, db_name, core_dir)
         architectures[host] = {

--- a/tests/test-channel-hosts.sh
+++ b/tests/test-channel-hosts.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Which hosts a channel offers comes off the core release, not a list here.
+#
+# The list here fell behind: the core published nine hosts and the channel
+# kept offering four, so musl, FreeBSD and Intel macOS had a core sitting in
+# a release that no client would ever be told about. A release carries one
+# database per host it published, so that is what decides.
+
+set -euo pipefail
+
+directory=$(cd "$(dirname "$0")/.." && pwd -P)
+generator="$directory/scripts/generate-channel-manifest.py"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+# --core-dir keeps this off the network: the question is which names become
+# architectures, not how a digest is fetched.
+generate()
+{
+	rm -rf "$work/core" "$work/packages" "$work/out"
+	mkdir -p "$work/core" "$work/packages"
+	for host in $1; do
+		printf 'database for %s\n' "$host" > "$work/core/$host.db"
+	done
+	printf 'packages\n' > "$work/packages/vita.db"
+	python3 "$generator" \
+		--core-release core-under-test --packages-release packages-under-test \
+		--channel nightly --sequence 1 \
+		--core-dir "$work/core" --packages-dir "$work/packages" \
+		--output-dir "$work/out"
+}
+
+architectures_of()
+{
+	python3 -c 'import json,sys; print(" ".join(sorted(json.load(open(sys.argv[1]))["core"]["architectures"])))' \
+		"$work/out/nightly.json"
+}
+
+check()
+{
+	description=$1
+	hosts=$2
+	expected=$3
+
+	if ! generate "$hosts" >/dev/null 2>&1; then
+		printf 'FAIL: %s: the generator refused\n' "$description" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	actual=$(architectures_of)
+	if [[ $actual != "$expected" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' \
+			"$description" "$expected" "$actual" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+# The nine the core publishes today. The four this used to hardcode are a
+# subset, so a wrong answer here is the exact bug that shipped.
+nine="aarch64-linux-gnu aarch64-linux-musl aarch64-unknown-freebsd
+	arm64-apple-darwin x86_64-apple-darwin x86_64-linux-gnu
+	x86_64-linux-musl x86_64-unknown-freebsd x86_64-w64-mingw32"
+check "every published host reaches the manifest" "$nine" \
+	"aarch64-linux-gnu aarch64-linux-musl aarch64-unknown-freebsd arm64-apple-darwin x86_64-apple-darwin x86_64-linux-gnu x86_64-linux-musl x86_64-unknown-freebsd x86_64-w64-mingw32"
+
+# A series pinned to an older core offers what that core has, and no more.
+check "an older core offers only its own hosts" \
+	"aarch64-linux-gnu arm64-apple-darwin x86_64-linux-gnu x86_64-w64-mingw32" \
+	"aarch64-linux-gnu arm64-apple-darwin x86_64-linux-gnu x86_64-w64-mingw32"
+
+# A core with no databases is not a channel with no hosts, it is a mistake.
+rm -rf "$work/core" "$work/packages" "$work/out"
+mkdir -p "$work/core" "$work/packages"
+printf 'packages\n' > "$work/packages/vita.db"
+if output=$(python3 "$generator" \
+		--core-release empty-core --packages-release packages-under-test \
+		--channel nightly --sequence 1 \
+		--core-dir "$work/core" --packages-dir "$work/packages" \
+		--output-dir "$work/out" 2>&1); then
+	printf 'FAIL: a core with no host database was accepted\n' >&2
+	failures=$((failures + 1))
+elif ! grep -qi 'no host database' <<< "$output"; then
+	printf 'FAIL: refusing an empty core did not say why: %s\n' "$output" >&2
+	failures=$((failures + 1))
+fi
+
+if (( failures )); then
+	printf '%d channel host check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+
+printf 'channel host derivation tests passed\n'


### PR DESCRIPTION
The core published nine hosts this morning. The channel is still offering four:

```
$ curl -s https://vitasdk.org/channels/nightly.json | jq '.core.architectures | keys'
["aarch64-linux-gnu", "arm64-apple-darwin", "x86_64-linux-gnu", "x86_64-w64-mingw32"]
```

The manifest is what `vdpm refresh` reads to learn which architectures it can configure, so a host missing from it is a host no client is ever told about. `sdk-snapshot-20260825.607.1` carries databases for all nine, and musl, FreeBSD and Intel macOS users cannot install from any of them.

The cause was a list in this file, kept by hand, that nobody moved when the matrix grew. Adding five entries would fix today and leave the same trap armed, so the list goes instead. The manifest maps one database per host, which means the databases a release carries *are* the hosts it published — the question the list was answering already has an authoritative answer inside the release.

An older core carries fewer, which is exactly what a series pinned to one needs: `2026.08` keeps its four with no special case, and it has no `release.json` to read either, which is why the databases and not that file are the source. A core carrying no database at all is refused by name rather than published as a channel offering nothing.

The release lookup sends a token when one is in the environment. The anonymous quota on a hosted runner is shared and routinely spent by whatever ran before; without the header it comes back as a bare 403 with nothing to suggest why.

`tests/test-channel-hosts.sh` covers the three cases through `--core-dir`, so it needs no network: nine databases produce nine architectures, four produce four, and none is an error that says so. Against the current generator the first case fails with exactly the discrepancy that shipped — nine expected, four produced.

(`tests/test-pipeline-contracts.sh` fails in a bare checkout with or without this change: it reads a sibling `packages/` working copy.)

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
