### PR TITLE
Listen for the announcement, and build an input once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,18 @@ on:
         description: Branch, tag or commit from vitasdk/buildscripts
         required: false
         type: string
+      profile:
+        description: World to build (leave empty for the policy default)
+        required: false
+        type: string
   push:
     branches: [master]
   pull_request:
+  # A backstop, not the trigger: buildscripts announces every revision it
+  # takes, and this catches the announcement that never arrived. An input
+  # already built stops at describe, so an idle run costs one job.
+  schedule:
+    - cron: "20 */6 * * *"
   repository_dispatch:
     types: [run_build]
 
@@ -18,8 +27,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # Which world this workflow drives; softfp wiring is separate follow-up work.
-  PROFILE: vita
+  # The world this workflow drives unless a trigger names another one.
+  DEFAULT_PROFILE: vita
   # Release policy, not build knowledge: which hosts must publish.
   REQUIRED_HOSTS: "x86_64-linux-gnu aarch64-linux-gnu arm64-apple-darwin x86_64-w64-mingw32"
 
@@ -32,13 +41,34 @@ jobs:
       build_id: ${{ steps.describe.outputs.build_id }}
       version: ${{ steps.describe.outputs.version }}
       series: ${{ steps.describe.outputs.series }}
+      profile: ${{ steps.ref.outputs.profile }}
       lock: ${{ steps.describe.outputs.lock }}
     steps:
       - id: ref
         shell: bash
+        env:
+          # Whoever asks for a build says which revision and which world;
+          # a schedule or a plain push asks for the policy default.
+          REQUESTED_REF: ${{ inputs.buildscripts_ref || github.event.client_payload.buildscripts_ref }}
+          REQUESTED_PROFILE: ${{ inputs.profile || github.event.client_payload.profile }}
         run: |
-          raw_ref='${{ inputs.buildscripts_ref }}'
-          echo "ref=${raw_ref:-master}" >> "$GITHUB_OUTPUT"
+          ref=${REQUESTED_REF:-master}
+          profile=${REQUESTED_PROFILE:-$DEFAULT_PROFILE}
+          # Whoever dispatches writes these; a value carrying a newline
+          # would write a second output of its choosing, and one of the
+          # outputs here decides whether the build runs at all.
+          [[ $ref =~ ^[A-Za-z0-9._/-]+$ ]] || {
+            echo "::error::refusing a buildscripts ref that is not a plain git ref"
+            exit 1
+          }
+          [[ $profile =~ ^[A-Za-z0-9._-]+$ ]] || {
+            echo "::error::refusing a profile name that is not a plain world name"
+            exit 1
+          }
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "profile=$profile" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
 
       - uses: actions/checkout@v7
         with:
@@ -50,6 +80,8 @@ jobs:
       - id: describe
         shell: bash
         working-directory: buildscripts
+        env:
+          PROFILE: ${{ steps.ref.outputs.profile }}
         run: |
           lock_path="$RUNNER_TEMP/lock.json"
           ./buildscripts-ci describe --profile "$PROFILE" --output "$lock_path"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       series: ${{ steps.describe.outputs.series }}
       profile: ${{ steps.ref.outputs.profile }}
       lock: ${{ steps.describe.outputs.lock }}
+      duplicate: ${{ steps.dedup.outputs.duplicate }}
     steps:
       - id: ref
         shell: bash
@@ -106,8 +107,35 @@ jobs:
             }
           done
 
+      - name: Stop if this input already has a published snapshot
+        id: dedup
+        # Never on a pull request: the input under test is whatever
+        # buildscripts master holds, so every pull request would find its
+        # own snapshot published and go green having built nothing.
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_ID: ${{ steps.describe.outputs.build_id }}
+        shell: bash
+        run: |
+          # Newest first, one page: deeper than any rebuild of an old input
+          # would reach, and a single request.
+          gh api "repos/${{ github.repository }}/releases?per_page=100" \
+            > "$RUNNER_TEMP/releases.json"
+          published=$(python3 scripts/find-built-snapshot.py \
+            --build-id "$BUILD_ID" --releases "$RUNNER_TEMP/releases.json")
+          if [[ -n $published ]]; then
+            echo "duplicate=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$BUILD_ID is already published as $published; nothing to build"
+          else
+            echo "duplicate=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     needs: prepare
+    # The deduplication key is the build input, never the run number: the
+    # same revision and world announced twice builds once.
+    if: needs.prepare.outputs.duplicate != 'true'
     uses: vitasdk/buildscripts/.github/workflows/build-sdk.yml@master
     with:
       lock: ${{ needs.prepare.outputs.lock }}
@@ -168,9 +196,18 @@ jobs:
           printf '%s\n' "$LOCK_JSON" > publish/lock.json
           snapshot_tag="sdk-snapshot-$(date -u +%Y%m%d).${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
           echo "snapshot_tag=$snapshot_tag" >> "$GITHUB_OUTPUT"
+          # The build_id line is what the next run reads to know this input
+          # is already published; keep it a line of its own.
+          cat > "$RUNNER_TEMP/notes.md" <<NOTES
+          Package-managed SDK preview built from buildscripts revision ${{ needs.prepare.outputs.buildscripts_revision }}.
+
+          build_id: ${{ needs.prepare.outputs.build_id }}
+          profile: ${{ needs.prepare.outputs.profile }}
+          version: ${{ needs.prepare.outputs.version }}
+          NOTES
           gh release create "$snapshot_tag" --draft --prerelease \
             --target "$GITHUB_SHA" --title "$snapshot_tag" \
-            --notes "Package-managed SDK preview built from buildscripts revision ${{ needs.prepare.outputs.buildscripts_revision }}."
+            --notes-file "$RUNNER_TEMP/notes.md"
           gh release upload "$snapshot_tag" publish/*
           mkdir downloaded-release
           gh release download "$snapshot_tag" --dir downloaded-release

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,35 @@
+name: Checks
+
+# The tests in this repository had nothing running them: they passed on
+# whoever remembered to run them by hand.
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: autobuilds
+
+      - name: Check out the recipes the pipeline contracts read
+        uses: actions/checkout@v7
+        with:
+          repository: vitasdk/packages
+          path: packages
+
+      - name: Install what the tests import
+        shell: bash
+        run: python3 -c 'import yaml' 2>/dev/null || sudo apt-get install -y python3-yaml
+
+      - name: Run the tests
+        shell: bash
+        working-directory: autobuilds
+        run: |
+          for test in tests/test-*.sh; do
+            echo "== $test"
+            "$test"
+          done

--- a/scripts/find-built-snapshot.py
+++ b/scripts/find-built-snapshot.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Answers whether a build input already has a published snapshot."""
+
+import argparse
+import json
+import re
+import sys
+
+# Only a line of its own counts: a build_id quoted in prose, or in a note
+# about some other snapshot, must never pass for the record of this one.
+MARKER = re.compile(r"^build_id:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+
+
+class LookupError_(Exception):
+    pass
+
+
+def find_snapshot(releases, build_id):
+    if not isinstance(releases, list):
+        raise LookupError_("the release listing is not a JSON array")
+    for release in releases:
+        if not isinstance(release, dict):
+            raise LookupError_(f"the release listing holds a {type(release).__name__}")
+        # A draft is a snapshot that was never published: whoever was
+        # uploading it may have died halfway, so it proves nothing.
+        if release.get("draft"):
+            continue
+        match = MARKER.search(release.get("body") or "")
+        if match and match.group(1) == build_id:
+            tag = release.get("tag_name")
+            if not tag:
+                raise LookupError_(f"a release recording {build_id} has no tag")
+            return tag
+    return None
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(prog="find-built-snapshot")
+    parser.add_argument("--build-id", required=True)
+    parser.add_argument("--releases", default="-", help="GitHub release listing, or - for stdin")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.releases == "-":
+            releases = json.load(sys.stdin)
+        else:
+            with open(args.releases, encoding="utf-8") as handle:
+                releases = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"find-built-snapshot: {args.releases} is not readable JSON: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        tag = find_snapshot(releases, args.build_id)
+    except LookupError_ as exc:
+        print(f"find-built-snapshot: {exc}", file=sys.stderr)
+        return 1
+
+    if tag:
+        print(tag)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test-build-dedup.sh
+++ b/tests/test-build-dedup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# An input that already has a published snapshot is not built again, and
+# what publishes the snapshot writes the record the next run reads.
+
+set -euo pipefail
+
+directory=$(cd "$(dirname "$0")/.." && pwd -P)
+finder="$directory/scripts/find-built-snapshot.py"
+workflow="$directory/.github/workflows/build.yml"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+check() {
+	local description=$1
+	shift
+	if "$@"; then
+		printf 'PASS: %s\n' "$description"
+	else
+		printf 'FAIL: %s\n' "$description" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+find_snapshot() {
+	python3 "$finder" --build-id "$1" --releases "$2"
+}
+
+published='sha256:1111111111111111111111111111111111111111111111111111111111111111'
+other='sha256:2222222222222222222222222222222222222222222222222222222222222222'
+
+cat > "$work/releases.json" <<JSONEOF
+[
+  {"tag_name": "sdk-snapshot-20260825.3.1", "draft": false,
+   "body": "Preview built from buildscripts revision aaaa.\n\nbuild_id: $other\nprofile: vita\n"},
+  {"tag_name": "sdk-snapshot-20260825.2.1", "draft": true,
+   "body": "Preview built from buildscripts revision bbbb.\n\nbuild_id: $published\nprofile: vita\n"},
+  {"tag_name": "sdk-snapshot-20260825.1.1", "draft": false,
+   "body": "Preview built from buildscripts revision cccc.\n\nbuild_id: $published\nprofile: vita\n"}
+]
+JSONEOF
+
+check "a published snapshot for the input is found" \
+	[ "$(find_snapshot "$published" "$work/releases.json")" = "sdk-snapshot-20260825.1.1" ]
+
+# A draft is a snapshot whose upload may have died halfway through.
+cat > "$work/draft-only.json" <<JSONEOF
+[
+  {"tag_name": "sdk-snapshot-20260825.2.1", "draft": true,
+   "body": "build_id: $published\n"}
+]
+JSONEOF
+check "a draft does not count as published" \
+	[ -z "$(find_snapshot "$published" "$work/draft-only.json")" ]
+
+check "an unbuilt input finds nothing" \
+	[ -z "$(find_snapshot "sha256:3333" "$work/releases.json")" ]
+
+check "an empty listing finds nothing" \
+	bash -c "echo '[]' | python3 '$finder' --build-id '$published' | grep -q . && exit 1 || exit 0"
+
+# The record is a line, not a mention: a note about some other snapshot
+# must not stop a build that has to happen.
+cat > "$work/prose.json" <<JSONEOF
+[
+  {"tag_name": "sdk-snapshot-20260825.4.1", "draft": false,
+   "body": "Rebuilt because build_id: $published was wrong.\n"}
+]
+JSONEOF
+check "a build_id quoted in prose is not a record" \
+	[ -z "$(find_snapshot "$published" "$work/prose.json")" ]
+
+check "a listing that is not an array fails loudly" \
+	bash -c "echo '{}' | python3 '$finder' --build-id '$published' 2>/dev/null && exit 1 || exit 0"
+
+# What publish writes has to be what the finder reads. Take the notes the
+# workflow builds, fill in what Actions would fill in, and look for it.
+python3 - "$workflow" "$published" > "$work/rendered-notes.md" <<'PYEOF'
+import re, sys
+text = open(sys.argv[1]).read()
+match = re.search(r"<<NOTES\n(.*?)\n\s*NOTES\n", text, re.DOTALL)
+if not match:
+    sys.exit("the publish step no longer builds its notes with a NOTES heredoc")
+lines = match.group(1).split("\n")
+indent = min(len(line) - len(line.lstrip()) for line in lines if line.strip())
+body = "\n".join(line[indent:] for line in lines)
+body = body.replace("${{ needs.prepare.outputs.build_id }}", sys.argv[2])
+sys.stdout.write(re.sub(r"\$\{\{[^}]*\}\}", "filled-in", body) + "\n")
+PYEOF
+python3 - "$work/rendered-notes.md" > "$work/rendered.json" <<'PYEOF'
+import json, sys
+body = open(sys.argv[1]).read()
+json.dump([{"tag_name": "sdk-snapshot-rendered", "draft": False, "body": body}], sys.stdout)
+PYEOF
+check "the snapshot notes record the build_id the finder looks for" \
+	[ "$(find_snapshot "$published" "$work/rendered.json")" = "sdk-snapshot-rendered" ]
+
+# Deduplication must not reach a pull request: what it describes there is
+# whatever buildscripts master holds, which is exactly what is published.
+check "deduplication is skipped on pull requests" \
+	grep -q "if: github.event_name != 'pull_request'" "$workflow"
+check "the build is gated on the deduplication result" \
+	grep -q "if: needs.prepare.outputs.duplicate != 'true'" "$workflow"
+
+if [[ $failures -gt 0 ]]; then
+	printf '%s check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+printf 'build deduplication: all checks passed\n'

--- a/tests/test-build-triggers.sh
+++ b/tests/test-build-triggers.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# What a build is of -- which revision, which world -- comes from whoever
+# asked for it, and a dispatch cannot write anything else into the run.
+
+set -euo pipefail
+
+directory=$(cd "$(dirname "$0")/.." && pwd -P)
+workflow="$directory/.github/workflows/build.yml"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+check() {
+	local description=$1
+	shift
+	if "$@"; then
+		printf 'PASS: %s\n' "$description"
+	else
+		printf 'FAIL: %s\n' "$description" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+# The step that reads the trigger, run exactly as Actions runs it.
+python3 - "$workflow" "$work" <<'PYEOF'
+import sys, yaml
+workflow, work = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(open(workflow))
+steps = doc["jobs"]["prepare"]["steps"]
+step = next((s for s in steps if s.get("id") == "ref"), None)
+if step is None:
+    sys.exit("the prepare job no longer has a step with id 'ref'")
+open(f"{work}/ref-step.sh", "w").write(step["run"])
+open(f"{work}/default-profile", "w").write(doc["env"]["DEFAULT_PROFILE"])
+PYEOF
+
+default_profile=$(cat "$work/default-profile")
+
+run_ref_step() {
+	local output="$work/output"
+	: > "$output"
+	env -i PATH="$PATH" HOME="$HOME" \
+		GITHUB_OUTPUT="$output" \
+		DEFAULT_PROFILE="$default_profile" \
+		REQUESTED_REF="${1-}" REQUESTED_PROFILE="${2-}" \
+		bash "$work/ref-step.sh" > "$work/stdout" 2>&1
+}
+
+output_value() {
+	sed -n "s/^$1=//p" "$work/output"
+}
+
+run_ref_step "" ""
+check "an unasked build takes the development branch" \
+	[ "$(output_value ref)" = "master" ]
+check "an unasked build takes the policy default world" \
+	[ "$(output_value profile)" = "$default_profile" ]
+
+run_ref_step "8c1e5f9d2b" "vita-softfp"
+check "a trigger that names a revision is obeyed" \
+	[ "$(output_value ref)" = "8c1e5f9d2b" ]
+check "a trigger that names a world is obeyed" \
+	[ "$(output_value profile)" = "vita-softfp" ]
+
+# An output of this step decides whether the build runs at all, so a
+# payload that carries a newline must not get to write a second one.
+if run_ref_step "master" "vita
+duplicate=true"; then
+	printf 'FAIL: a profile carrying a newline was accepted\n' >&2
+	failures=$((failures + 1))
+else
+	printf 'PASS: a profile carrying a newline is refused\n'
+fi
+check "the refused profile wrote no output" \
+	[ -z "$(output_value duplicate)" ]
+
+if run_ref_step "master
+duplicate=true" ""; then
+	printf 'FAIL: a ref carrying a newline was accepted\n' >&2
+	failures=$((failures + 1))
+else
+	printf 'PASS: a ref carrying a newline is refused\n'
+fi
+check "the refused ref wrote no output" \
+	[ -z "$(output_value duplicate)" ]
+
+# The triggers themselves: an announcement from buildscripts, and a
+# schedule for the announcement that never arrives.
+python3 - "$workflow" <<'PYEOF'
+import sys, yaml
+doc = yaml.safe_load(open(sys.argv[1]))
+# YAML reads a bare `on` as the boolean True.
+triggers = doc.get("on", doc.get(True))
+missing = [name for name in ("schedule", "repository_dispatch", "workflow_dispatch")
+           if name not in triggers]
+if missing:
+    sys.exit("build.yml declares no " + ", ".join(missing))
+if "run_build" not in triggers["repository_dispatch"]["types"]:
+    sys.exit("build.yml does not listen for the run_build announcement")
+if not triggers["schedule"]:
+    sys.exit("build.yml declares an empty schedule")
+inputs = triggers["workflow_dispatch"]["inputs"]
+for name in ("buildscripts_ref", "profile"):
+    if name not in inputs:
+        sys.exit(f"a manual run cannot name {name}")
+PYEOF
+printf 'PASS: the triggers are declared\n'
+
+if [[ $failures -gt 0 ]]; then
+	printf '%s check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+printf 'build triggers: all checks passed\n'


### PR DESCRIPTION
The other half of discovery. `vitasdk/buildscripts#167` announces every revision that lands on its development branch; this side listens, decides whether that revision is worth building, and stops when it is not.

**What a build is of comes from whoever asked for it.** The workflow described whatever `buildscripts` master held and always the `vita` world, so a maintainer could not ask for a specific commit through a dispatch, and a second world had nowhere to enter. A trigger now names the revision and the world; a plain push or a schedule asks for the policy default. What a dispatch sends is checked before it becomes a step output — one of the outputs of that step decides whether the build runs at all, and a value carrying a newline would write a second one of its own choosing.

**The schedule is a backstop, not the trigger.** Every six hours, in case an announcement never arrived. It is cheap precisely because of the next part.

**An input is built once, however many times it is announced.** Today a push, the schedule that follows it and a manual run of the same revision each pay for the same nine-host SDK. The published snapshot now records the `build_id` it came from, and a run that finds one for its own input stops before any runner is asked for. The key is the build input — the `buildscripts` revision and the world — never the run number, which is why the record travels in the release and not in this repository. There are two snapshots from `79a92784` in the last hundred alone.

Rehearsed against the real listing, with the real describe output:

```
$ buildscripts-ci describe --profile vita --revision origin/master | jq -r .build_id
sha256:df2f3c490e625743b12aaa4d21ce4e1b806e48a7d94c7ad85433a4bc2a8aed69
$ gh api "repos/vitasdk/autobuilds/releases?per_page=100" > releases.json
$ python3 scripts/find-built-snapshot.py --build-id sha256:df2f... --releases releases.json
                                    # nothing: no snapshot carries the record yet, so it builds
$ python3 scripts/find-built-snapshot.py --build-id sha256:df2f... --releases marked.json
sdk-snapshot-20260825.612.1         # the same listing with the notes this PR writes
```

A draft does not count as published: whoever was uploading it may have died halfway. Neither does a `build_id` quoted in prose — only a line of its own.

**Deduplication is skipped on pull requests**, and that is the point of the `if`. What a pull request here describes is whatever `buildscripts` master holds, which is exactly what is already published, so every pull request would find its own snapshot and go green having built nothing.

**The tests in this repository had nothing running them.** Four files, passing whenever somebody remembered. `checks.yml` runs them on push and pull request, with `vitasdk/packages` checked out beside this repository — `tests/test-pipeline-contracts.sh` reads a sibling working copy, which is why it fails in a bare checkout today (noted on #35). All five now pass in that layout.

`tests/test-build-triggers.sh` extracts the trigger step from the workflow and runs it as Actions runs it, including the two newline payloads. `tests/test-build-dedup.sh` renders the notes the publish step writes and feeds them to the finder, so the writer and the reader cannot drift apart without a test failing.

Merge order does not matter: this half is inert until something announces, and the buildscripts half needs `REPO_DISPATCH_TOKEN` added to that repository before its announcement can send at all.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
